### PR TITLE
Add comments to deploy.yml how to fix the broken GitHub action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,8 @@
 # This file was created automatically with `myst init --gh-pages` 🪄 💚
+# GitHub Pages must be turned on for this action to work
+# Navigate to Settings -> Pages for this repository
+# Where `Source` should be set to `GitHub Actions`
+# Then rerun this action
 
 name: MyST GitHub Pages Deploy
 on:


### PR DESCRIPTION
In case someone does not read the instructions in getting-started.md they can see the instructions here in the GitHub action file when the action fails. I also submitted an issue to the mystmd repository to put instructions in this file by default for all future users of `myst init --gh-pages`.